### PR TITLE
Removed selection of line numbers when selecting with mouse

### DIFF
--- a/css/CodeStyler.css
+++ b/css/CodeStyler.css
@@ -39,6 +39,7 @@ pre + button
 }
 
 pre .line-number {
+    user-select: none;
     float: left;
     margin: 0 1em 0 -1em;
     border-right: 1px solid;

--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
         <span class="fa fa-github"></span> View on GitHub</a>
       <a href="http://www.linkedin.com/shareArticle?mini=false&url=https://itbackyard.dk/codestyler&title=Code%20Styler&summary=Simple%20Code%20Styler&source=https://itbackyard.dk" class="btn btn-primary">
         <span class="fa fa-linkedin"></span> Share on LinkedIn</a>
-      <a href="http://www.twitter.com/intent/tweet?url=https://itbackyard.dk/codestyler&text=Open Source Simple Code Styler for html using CSS and JavaScript" class="btn btn-primary" style="background-color: #38A1F3">
-      <span class="fa fa-twitter"></span> Tweet</a>
+      <!-- <a href="http://www.twitter.com/intent/tweet?url=https://itbackyard.dk/codestyler&text=Open Source Simple Code Styler for html using CSS and JavaScript" class="btn btn-primary" style="background-color: #38A1F3"> -->
+      <!-- <span class="fa fa-twitter"></span> Tweet</a> -->
     </div>
   </header>
 


### PR DESCRIPTION
Now when selecting code with mouse it wont select the line numbers on the side.
Simple CSS rule that only applies to the line number class.